### PR TITLE
Revert "Bump softprops/action-gh-release from 2.1.0 to 2.2.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
           zip family_safety.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           files: ${{ github.workspace }}/custom_components/family_safety/family_safety.zip


### PR DESCRIPTION
Reverts pantherale0/ha-familysafety#71

Fixes release (https://github.com/softprops/action-gh-release/issues/556)